### PR TITLE
Adding instant-test route

### DIFF
--- a/src/instant-test/instant-test.component.js
+++ b/src/instant-test/instant-test.component.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { LocalStorageContext } from "../shared/use-local-storage-data.hook";
+
+export default function InstantTest(props) {
+  const params = new URLSearchParams(location.search);
+  const isValid = params.has("name") && params.has("url");
+  const { applications, addApplication, updateApplication } = React.useContext(
+    LocalStorageContext
+  );
+
+  React.useEffect(() => {
+    if (!isValid) {
+      return;
+    }
+
+    const app = { name: params.get("name"), pathPrefix: "/" };
+    if (applications.some(app => app.name === params.get("name"))) {
+      updateApplication(app, params.get("name"));
+    } else {
+      addApplication(app);
+    }
+
+    window.importMapOverrides.addOverride(
+      params.get("name"),
+      params.get("url")
+    );
+
+    location.assign("/");
+  }, [isValid]);
+
+  if (isValid) {
+    return null;
+  } else {
+    return "Please provide name and url query params to use this feature";
+  }
+}

--- a/src/playground.component.js
+++ b/src/playground.component.js
@@ -16,6 +16,7 @@ import Navbars from "./navbars/navbars.component";
 import ImportMap from "./import-map/import-map.component";
 import HtmlFile from "./html-file/html-file.component";
 import Stuck from "./stuck/stuck.component";
+import InstantTest from "./instant-test/instant-test.component";
 
 export default function Playground(props) {
   const scope = useCss(css);
@@ -38,6 +39,7 @@ export default function Playground(props) {
                 <Route path="/app/:appName" component={TestApp} />
                 <Route path="/html-file" component={HtmlFile} />
                 <Route path="/stuck" component={Stuck} />
+                <Route path="/instant-test" component={InstantTest} />
               </BrowserRouter>
             </div>
           </div>


### PR DESCRIPTION
This will be used by create-single-spa and also will just be a nice way to instantly test whether a single-spa application is working or not. You can go to http://single-spa-playground.org/playground/instant-test?name=app-name&url=8080 and it will register a single-spa application for you and then try to mount it.